### PR TITLE
Update Dockerfile to base FROM Centos node4 image

### DIFF
--- a/fh-messaging/docker/Dockerfile
+++ b/fh-messaging/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhscl/nodejs-4-rhel7
+FROM centos/nodejs-4-centos7
 
 EXPOSE 8080
 

--- a/fh-messaging/npm-shrinkwrap.json
+++ b/fh-messaging/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-messaging",
-  "version": "3.0.3-BUILD-NUMBER",
+  "version": "3.0.4-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.6",

--- a/fh-messaging/package.json
+++ b/fh-messaging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-messaging",
   "description": "FeedHenry Messaging Server",
-  "version": "3.0.3-BUILD-NUMBER",
+  "version": "3.0.4-BUILD-NUMBER",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-messaging.git"

--- a/fh-messaging/sonar-project.properties
+++ b/fh-messaging/sonar-project.properties
@@ -1,3 +1,3 @@
 sonar.projectKey=fh-messaging
 sonar.projectName=fh-messaging-nightly-master
-sonar.projectVersion=3.0.3
+sonar.projectVersion=3.0.4

--- a/fh-metrics/docker/Dockerfile
+++ b/fh-metrics/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhscl/nodejs-4-rhel7
+FROM centos/nodejs-4-centos7
 
 EXPOSE 8080
 

--- a/fh-metrics/npm-shrinkwrap.json
+++ b/fh-metrics/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-metrics",
-  "version": "3.0.3-BUILD-NUMBER",
+  "version": "3.0.4-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "1.5.2",

--- a/fh-metrics/package.json
+++ b/fh-metrics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-metrics",
   "description": "FeedHenry Metrics Server",
-  "version": "3.0.3-BUILD-NUMBER",
+  "version": "3.0.4-BUILD-NUMBER",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-messaging.git"

--- a/fh-metrics/sonar-project.properties
+++ b/fh-metrics/sonar-project.properties
@@ -1,3 +1,3 @@
 sonar.projectKey=fh-metrics
 sonar.projectName=fh-metrics-nightly-master
-sonar.projectVersion=3.0.3
+sonar.projectVersion=3.0.4


### PR DESCRIPTION
Since Open sourcing this project we no longer want to inherit from RHEL image where user would need subscription in place to pull the Docker image.
