### PR TITLE
Rhmap 16416 - Prevent fh-messaging from "flooding" the mongo servers

### DIFF
--- a/fh-messaging/config/dev.json
+++ b/fh-messaging/config/dev.json
@@ -159,5 +159,6 @@
   },
   "geoip": {
     "dataFile": "./vendor/GeoIP.dat"
-  }
+  },
+  "maxRequests": 1000000
 }

--- a/fh-messaging/npm-shrinkwrap.json
+++ b/fh-messaging/npm-shrinkwrap.json
@@ -4,121 +4,121 @@
   "dependencies": {
     "async": {
       "version": "0.2.6",
-      "from": "https://registry.npmjs.org/async/-/async-0.2.6.tgz",
+      "from": "async@0.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.6.tgz"
     },
     "body-parser": {
       "version": "1.14.1",
-      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.1.tgz",
+      "from": "body-parser@1.14.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.1.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
+          "from": "bytes@2.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
         },
         "content-type": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+          "from": "content-type@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "http://npm.skunkhenry.com/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+              "from": "ms@0.7.1",
+              "resolved": "http://npm.skunkhenry.com/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "from": "depd@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "http-errors": {
           "version": "1.3.1",
-          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+          "from": "http-errors@>=1.3.1 <1.4.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "statuses": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+              "from": "statuses@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
             }
           }
         },
         "iconv-lite": {
           "version": "0.4.12",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.12.tgz",
+          "from": "iconv-lite@0.4.12",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.12.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "from": "on-finished@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+              "from": "ee-first@1.1.1",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "qs": {
           "version": "5.1.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
+          "from": "qs@5.1.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
         },
         "raw-body": {
           "version": "2.1.7",
-          "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+          "from": "raw-body@>=2.1.4 <2.2.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
           "dependencies": {
             "bytes": {
               "version": "2.4.0",
-              "from": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+              "from": "bytes@2.4.0",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
             },
             "iconv-lite": {
               "version": "0.4.13",
-              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+              "from": "iconv-lite@0.4.13",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
             },
             "unpipe": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "from": "unpipe@1.0.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "type-is": {
-          "version": "1.6.13",
-          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "version": "1.6.15",
+          "from": "type-is@>=1.6.9 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "from": "media-typer@0.3.0",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.12",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "version": "2.1.15",
+              "from": "mime-types@>=2.1.15 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.24.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                  "version": "1.27.0",
+                  "from": "mime-db@>=1.27.0 <1.28.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
                 }
               }
             }
@@ -128,239 +128,285 @@
     },
     "express": {
       "version": "4.14.0",
-      "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+      "from": "express@4.14.0",
       "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
-          "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "from": "accepts@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.1.12",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "version": "2.1.15",
+              "from": "mime-types@>=2.1.15 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.24.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                  "version": "1.27.0",
+                  "from": "mime-db@>=1.27.0 <1.28.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+              "from": "negotiator@0.6.1",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
             }
           }
         },
         "array-flatten": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "from": "array-flatten@1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
         },
         "content-disposition": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+          "from": "content-disposition@0.5.1",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
         },
         "content-type": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+          "from": "content-type@>=1.0.2 <1.1.0",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "cookie": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "from": "cookie@0.3.1",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "from": "cookie-signature@1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "http://npm.skunkhenry.com/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+              "from": "ms@0.7.1",
+              "resolved": "http://npm.skunkhenry.com/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "from": "depd@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "encodeurl": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+          "from": "encodeurl@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
         },
         "escape-html": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+          "from": "escape-html@>=1.0.3 <1.1.0",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
         },
         "etag": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+          "from": "etag@>=1.7.0 <1.8.0",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
         },
         "finalhandler": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+          "from": "finalhandler@0.5.0",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
           "dependencies": {
             "statuses": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+              "from": "statuses@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
             },
             "unpipe": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "from": "unpipe@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "fresh": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+          "from": "fresh@0.3.0",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
         },
         "merge-descriptors": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+          "from": "merge-descriptors@1.0.1",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
         },
         "methods": {
           "version": "1.1.2",
-          "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "from": "methods@>=1.1.2 <1.2.0",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "from": "on-finished@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+              "from": "ee-first@1.1.1",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.1",
-          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "from": "parseurl@>=1.3.1 <1.4.0",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "from": "path-to-regexp@0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
         },
         "proxy-addr": {
-          "version": "1.1.2",
-          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
+          "version": "1.1.4",
+          "from": "proxy-addr@>=1.1.2 <1.2.0",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+              "from": "forwarded@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
+              "version": "1.3.0",
+              "from": "ipaddr.js@1.3.0",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
             }
           }
         },
         "qs": {
           "version": "6.2.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+          "from": "qs@6.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         },
         "range-parser": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+          "from": "range-parser@>=1.2.0 <1.3.0",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
         },
         "send": {
           "version": "0.14.1",
-          "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+          "from": "send@0.14.1",
           "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+              "from": "destroy@>=1.0.4 <1.1.0",
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
             },
             "http-errors": {
               "version": "1.5.1",
-              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+              "from": "http-errors@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "from": "inherits@2.0.3",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "setprototypeof": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+                  "from": "setprototypeof@1.0.2",
                   "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "from": "mime@1.3.4",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
               "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+              "from": "ms@0.7.1",
+              "resolved": "http://npm.skunkhenry.com/ms/-/ms-0.7.1.tgz"
             },
             "statuses": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+              "from": "statuses@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
             }
           }
         },
         "serve-static": {
-          "version": "1.11.1",
-          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
+          "version": "1.11.2",
+          "from": "serve-static@>=1.11.1 <1.12.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz",
+          "dependencies": {
+            "send": {
+              "version": "0.14.2",
+              "from": "send@0.14.2",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
+              "dependencies": {
+                "destroy": {
+                  "version": "1.0.4",
+                  "from": "destroy@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+                },
+                "http-errors": {
+                  "version": "1.5.1",
+                  "from": "http-errors@>=1.5.1 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@2.0.3",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "setprototypeof": {
+                      "version": "1.0.2",
+                      "from": "setprototypeof@1.0.2",
+                      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "from": "mime@1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                },
+                "ms": {
+                  "version": "0.7.2",
+                  "from": "ms@0.7.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                },
+                "statuses": {
+                  "version": "1.3.1",
+                  "from": "statuses@>=1.3.1 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+                }
+              }
+            }
+          }
         },
         "type-is": {
-          "version": "1.6.13",
-          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "version": "1.6.15",
+          "from": "type-is@>=1.6.13 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "from": "media-typer@0.3.0",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.12",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "version": "2.1.15",
+              "from": "mime-types@>=2.1.15 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.24.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                  "version": "1.27.0",
+                  "from": "mime-db@>=1.27.0 <1.28.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
                 }
               }
             }
@@ -368,105 +414,105 @@
         },
         "utils-merge": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "from": "utils-merge@1.0.0",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         },
         "vary": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+          "version": "1.1.1",
+          "from": "vary@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
         }
       }
     },
     "express-bunyan-logger": {
       "version": "1.3.1",
-      "from": "https://registry.npmjs.org/express-bunyan-logger/-/express-bunyan-logger-1.3.1.tgz",
+      "from": "express-bunyan-logger@1.3.1",
       "resolved": "https://registry.npmjs.org/express-bunyan-logger/-/express-bunyan-logger-1.3.1.tgz",
       "dependencies": {
         "bunyan": {
-          "version": "1.8.5",
-          "from": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.5.tgz",
-          "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.5.tgz",
+          "version": "1.8.10",
+          "from": "bunyan@>=1.8.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.10.tgz",
           "dependencies": {
             "dtrace-provider": {
-              "version": "0.8.0",
-              "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.0.tgz",
-              "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.0.tgz",
+              "version": "0.8.3",
+              "from": "dtrace-provider@>=0.8.0 <0.9.0",
+              "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.3.tgz",
               "dependencies": {
                 "nan": {
-                  "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+                  "version": "2.6.2",
+                  "from": "nan@>=2.3.3 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
                 }
               }
             },
             "mv": {
               "version": "2.1.1",
-              "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+              "from": "mv@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "from": "mkdirp@0.5.1",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "ncp": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                  "from": "ncp@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.4.5",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                  "from": "rimraf@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "6.0.4",
-                      "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                      "from": "glob@>=6.0.1 <7.0.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.6",
-                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                          "from": "inflight@>=1.0.4 <2.0.0",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "from": "inherits@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "minimatch": {
-                          "version": "3.0.3",
-                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                          "version": "3.0.4",
+                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.6",
-                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                              "version": "1.1.8",
+                              "from": "brace-expansion@>=1.1.7 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                               "dependencies": {
                                 "balanced-match": {
-                                  "version": "0.4.2",
-                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                                  "version": "1.0.0",
+                                  "from": "balanced-match@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "from": "concat-map@0.0.1",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
@@ -475,19 +521,19 @@
                         },
                         "once": {
                           "version": "1.4.0",
-                          "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                          "from": "once@>=1.4.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                         }
                       }
@@ -497,36 +543,48 @@
               }
             },
             "safe-json-stringify": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz"
+              "version": "1.0.4",
+              "from": "safe-json-stringify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz"
             }
           }
         },
         "lodash.has": {
           "version": "4.5.2",
-          "from": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+          "from": "lodash.has@>=4.5.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz"
         },
         "lodash.set": {
           "version": "4.3.2",
-          "from": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+          "from": "lodash.set@>=4.3.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz"
         },
         "node-uuid": {
-          "version": "1.4.7",
-          "from": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-          "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+          "version": "1.4.8",
+          "from": "node-uuid@>=1.4.7 <2.0.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
         },
         "useragent": {
-          "version": "2.1.9",
-          "from": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
-          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
+          "version": "2.2.1",
+          "from": "useragent@>=2.1.9 <3.0.0",
+          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+              "from": "lru-cache@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
+            },
+            "tmp": {
+              "version": "0.0.31",
+              "from": "tmp@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+              "dependencies": {
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "from": "os-tmpdir@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                }
+              }
             }
           }
         }
@@ -534,104 +592,104 @@
     },
     "fh-agenda": {
       "version": "0.9.0",
-      "from": "https://registry.npmjs.org/fh-agenda/-/fh-agenda-0.9.0.tgz",
+      "from": "fh-agenda@0.9.0",
       "resolved": "https://registry.npmjs.org/fh-agenda/-/fh-agenda-0.9.0.tgz",
       "dependencies": {
         "cron": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/cron/-/cron-1.1.1.tgz",
+          "from": "cron@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/cron/-/cron-1.1.1.tgz"
         },
         "date.js": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/date.js/-/date.js-0.3.1.tgz",
+          "from": "date.js@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.1.tgz",
           "dependencies": {
             "debug": {
               "version": "0.7.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "from": "debug@>=0.7.2 <0.8.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             },
             "lodash.filter": {
               "version": "4.6.0",
-              "from": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+              "from": "lodash.filter@>=4.2.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz"
             },
             "lodash.findkey": {
               "version": "4.6.0",
-              "from": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
+              "from": "lodash.findkey@>=4.2.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz"
             },
             "lodash.foreach": {
               "version": "4.5.0",
-              "from": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+              "from": "lodash.foreach@>=4.1.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz"
             },
             "lodash.includes": {
               "version": "4.3.0",
-              "from": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+              "from": "lodash.includes@>=4.1.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz"
             },
             "lodash.isempty": {
               "version": "4.4.0",
-              "from": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+              "from": "lodash.isempty@>=4.1.2 <5.0.0",
               "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz"
             },
             "lodash.partition": {
               "version": "4.6.0",
-              "from": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+              "from": "lodash.partition@>=4.2.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz"
             },
             "lodash.trim": {
               "version": "4.5.1",
-              "from": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
+              "from": "lodash.trim@>=4.2.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz"
             }
           }
         },
         "human-interval": {
           "version": "0.1.6",
-          "from": "https://registry.npmjs.org/human-interval/-/human-interval-0.1.6.tgz",
+          "from": "human-interval@>=0.1.3 <0.2.0",
           "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-0.1.6.tgz"
         },
         "moment-timezone": {
-          "version": "0.5.9",
-          "from": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.9.tgz",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.9.tgz"
+          "version": "0.5.13",
+          "from": "moment-timezone@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz"
         },
         "mongodb": {
           "version": "2.1.11",
-          "from": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.11.tgz",
+          "from": "mongodb@2.1.11",
           "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.11.tgz",
           "dependencies": {
             "es6-promise": {
               "version": "3.0.2",
-              "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+              "from": "es6-promise@3.0.2",
               "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
             },
             "mongodb-core": {
               "version": "1.3.10",
-              "from": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.10.tgz",
+              "from": "mongodb-core@1.3.10",
               "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.10.tgz",
               "dependencies": {
                 "bson": {
                   "version": "0.4.23",
-                  "from": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+                  "from": "bson@>=0.4.21 <0.5.0",
                   "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
                 },
                 "require_optional": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+                  "version": "1.0.1",
+                  "from": "require_optional@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
                   "dependencies": {
                     "semver": {
                       "version": "5.3.0",
-                      "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                      "from": "semver@>=5.1.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                     },
                     "resolve-from": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                      "from": "resolve-from@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
                     }
                   }
@@ -640,27 +698,27 @@
             },
             "readable-stream": {
               "version": "1.0.31",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+              "from": "readable-stream@1.0.31",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
@@ -671,7 +729,7 @@
     },
     "fh-cluster": {
       "version": "0.3.0",
-      "from": "https://registry.npmjs.org/fh-cluster/-/fh-cluster-0.3.0.tgz",
+      "from": "fh-cluster@0.3.0",
       "resolved": "https://registry.npmjs.org/fh-cluster/-/fh-cluster-0.3.0.tgz",
       "dependencies": {
         "backoff": {
@@ -695,7 +753,7 @@
     },
     "fh-config": {
       "version": "1.0.3",
-      "from": "https://registry.npmjs.org/fh-config/-/fh-config-1.0.3.tgz",
+      "from": "fh-config@1.0.3",
       "resolved": "https://registry.npmjs.org/fh-config/-/fh-config-1.0.3.tgz",
       "dependencies": {
         "async": {
@@ -1177,7 +1235,7 @@
     },
     "fh-db": {
       "version": "1.2.4",
-      "from": "https://registry.npmjs.org/fh-db/-/fh-db-1.2.4.tgz",
+      "from": "fh-db@1.2.4",
       "resolved": "https://registry.npmjs.org/fh-db/-/fh-db-1.2.4.tgz",
       "dependencies": {
         "adm-zip": {
@@ -1474,105 +1532,120 @@
     },
     "fh-health": {
       "version": "0.3.1",
-      "from": "https://registry.npmjs.org/fh-health/-/fh-health-0.3.1.tgz",
+      "from": "fh-health@0.3.1",
       "resolved": "https://registry.npmjs.org/fh-health/-/fh-health-0.3.1.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.9",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
+          "from": "async@0.2.9",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
         },
         "fhlog": {
           "version": "0.12.1",
-          "from": "https://registry.npmjs.org/fhlog/-/fhlog-0.12.1.tgz",
+          "from": "fhlog@>=0.12.1 <0.13.0",
           "resolved": "https://registry.npmjs.org/fhlog/-/fhlog-0.12.1.tgz",
           "dependencies": {
             "safejson": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz",
+              "from": "safejson@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz"
             },
             "colors": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "from": "colors@>=1.0.3 <1.1.0",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "moment": {
               "version": "2.8.4",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
+              "from": "moment@>=2.8.4 <2.9.0",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
             },
             "async": {
               "version": "0.9.2",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "from": "async@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
             },
             "html5-fs": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz",
+              "from": "html5-fs@0.0.1",
               "resolved": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz"
             },
             "brfs": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/brfs/-/brfs-1.2.0.tgz",
+              "from": "brfs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.2.0.tgz",
               "dependencies": {
                 "quote-stream": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
+                  "from": "quote-stream@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "static-module": {
-                  "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
+                  "version": "1.4.0",
+                  "from": "static-module@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.4.0.tgz",
                   "dependencies": {
                     "concat-stream": {
-                      "version": "1.4.10",
-                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "version": "1.6.0",
+                      "from": "concat-stream@>=1.6.0 <1.7.0",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "from": "inherits@>=2.0.3 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "typedarray": {
                           "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "from": "typedarray@>=0.0.6 <0.0.7",
                           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
-                          "version": "1.1.14",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                          "version": "2.3.3",
+                          "from": "readable-stream@>=2.2.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
-                              "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.7",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                            },
+                            "safe-buffer": {
+                              "version": "5.1.1",
+                              "from": "safe-buffer@>=5.1.1 <5.2.0",
+                              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                             },
                             "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                              "version": "1.0.3",
+                              "from": "string_decoder@>=1.0.3 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                             }
                           }
                         }
@@ -1580,32 +1653,32 @@
                     },
                     "duplexer2": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                      "from": "duplexer2@>=0.0.2 <0.1.0",
                       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.1.14",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                          "from": "readable-stream@>=1.1.9 <1.2.0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "isarray@0.0.1",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.3",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                              "from": "inherits@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                             }
                           }
@@ -1614,32 +1687,32 @@
                     },
                     "escodegen": {
                       "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+                      "from": "escodegen@>=1.3.2 <1.4.0",
                       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                       "dependencies": {
                         "esutils": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+                          "from": "esutils@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                         },
                         "estraverse": {
                           "version": "1.5.1",
-                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
+                          "from": "estraverse@>=1.5.0 <1.6.0",
                           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                         },
                         "esprima": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
+                          "from": "esprima@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "from": "source-map@>=0.1.33 <0.2.0",
+                          "resolved": "http://npm.skunkhenry.com/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
                             }
                           }
@@ -1647,104 +1720,104 @@
                       }
                     },
                     "falafel": {
-                      "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+                      "version": "2.1.0",
+                      "from": "falafel@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
                       "dependencies": {
                         "acorn": {
-                          "version": "1.2.2",
-                          "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                          "version": "5.1.1",
+                          "from": "acorn@>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz"
                         },
                         "foreach": {
                           "version": "2.0.5",
-                          "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+                          "from": "foreach@>=2.0.5 <3.0.0",
                           "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "object-keys": {
                           "version": "1.0.11",
-                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+                          "from": "object-keys@>=1.0.6 <2.0.0",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
                         }
                       }
                     },
                     "has": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+                      "from": "has@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
                       "dependencies": {
                         "function-bind": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+                          "from": "function-bind@>=1.0.2 <2.0.0",
                           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
                         }
                       }
                     },
                     "object-inspect": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
+                      "from": "object-inspect@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz"
                     },
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                      "from": "readable-stream@>=1.0.27-1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         }
                       }
                     },
                     "shallow-copy": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+                      "from": "shallow-copy@>=0.0.1 <0.1.0",
                       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
                     },
                     "static-eval": {
                       "version": "0.2.4",
-                      "from": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
+                      "from": "static-eval@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
                       "dependencies": {
                         "escodegen": {
                           "version": "0.0.28",
-                          "from": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
+                          "from": "escodegen@>=0.0.24 <0.1.0",
                           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                           "dependencies": {
                             "esprima": {
                               "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                              "from": "esprima@>=1.0.2 <1.1.0",
                               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                             },
                             "estraverse": {
                               "version": "1.3.2",
-                              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
+                              "from": "estraverse@>=1.3.0 <1.4.0",
                               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
                             },
                             "source-map": {
                               "version": "0.5.6",
-                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                              "from": "source-map@>=0.1.2",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                             }
                           }
@@ -1755,44 +1828,44 @@
                 },
                 "through2": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                  "from": "through2@>=0.4.1 <0.5.0",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                      "from": "readable-stream@>=1.0.17 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                      "from": "xtend@>=2.1.1 <2.2.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "dependencies": {
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                          "from": "object-keys@>=0.4.0 <0.5.0",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -1803,7 +1876,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "from": "xtend@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -1812,7 +1885,7 @@
     },
     "fh-logger": {
       "version": "0.5.0",
-      "from": "https://registry.npmjs.org/fh-logger/-/fh-logger-0.5.0.tgz",
+      "from": "fh-logger@0.5.0",
       "resolved": "https://registry.npmjs.org/fh-logger/-/fh-logger-0.5.0.tgz",
       "dependencies": {
         "bunyan": {
@@ -1980,88 +2053,88 @@
     },
     "geoip": {
       "version": "0.6.1",
-      "from": "https://registry.npmjs.org/geoip/-/geoip-0.6.1.tgz",
+      "from": "geoip@0.6.1",
       "resolved": "https://registry.npmjs.org/geoip/-/geoip-0.6.1.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+          "from": "bindings@>=1.2.1 <1.3.0",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "http://npm.skunkhenry.com/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+              "from": "ms@0.7.1",
+              "resolved": "http://npm.skunkhenry.com/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "is-object": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+          "from": "is-object@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz"
         },
         "nan": {
           "version": "2.0.9",
-          "from": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz",
+          "from": "nan@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
         },
         "pangyp": {
           "version": "2.3.3",
-          "from": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.3.tgz",
+          "from": "pangyp@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.3.tgz",
           "dependencies": {
             "fstream": {
-              "version": "1.0.10",
-              "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+              "version": "1.0.11",
+              "from": "fstream@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "4.1.10",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                  "version": "4.1.11",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "from": "inherits@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
             "glob": {
               "version": "4.3.5",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "from": "glob@>=4.3.5 <4.4.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "once": {
                   "version": "1.4.0",
-                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
@@ -2070,34 +2143,34 @@
             },
             "graceful-fs": {
               "version": "3.0.11",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+              "from": "graceful-fs@>=3.0.5 <3.1.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
               "dependencies": {
                 "natives": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+                  "from": "natives@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "from": "minimatch@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.6",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "version": "1.1.8",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                      "version": "1.0.0",
+                      "from": "balanced-match@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -2106,86 +2179,86 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "nopt": {
               "version": "3.0.6",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "from": "nopt@>=3.0.1 <3.1.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+                  "version": "1.1.0",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
                 }
               }
             },
             "npmlog": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
+              "from": "npmlog@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
               "dependencies": {
                 "ansi": {
                   "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+                  "from": "ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
                 },
                 "are-we-there-yet": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+                  "from": "are-we-there-yet@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                      "from": "delegates@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                     },
                     "readable-stream": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+                      "version": "2.3.3",
+                      "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                       "dependencies": {
-                        "buffer-shims": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-                        },
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "from": "inherits@>=2.0.3 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
+                        "safe-buffer": {
+                          "version": "5.1.1",
+                          "from": "safe-buffer@>=5.1.1 <5.2.0",
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                        },
                         "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "1.0.3",
+                          "from": "string_decoder@>=1.0.3 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -2194,68 +2267,68 @@
                 },
                 "gauge": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
+                  "from": "gauge@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
                   "dependencies": {
                     "has-unicode": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                      "from": "has-unicode@>=1.0.0 <2.0.0",
+                      "resolved": "http://npm.skunkhenry.com/has-unicode/-/has-unicode-1.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "osenv": {
-              "version": "0.1.3",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "version": "0.1.4",
+              "from": "osenv@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
                 }
               }
             },
             "request": {
               "version": "2.51.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "from": "request@>=2.51.0 <2.52.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.5",
-                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+                  "from": "bl@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         }
                       }
@@ -2264,32 +2337,32 @@
                 },
                 "caseless": {
                   "version": "0.8.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+                  "from": "caseless@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "from": "form-data@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                      "from": "async@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     },
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "from": "mime-types@>=2.0.3 <2.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                          "from": "mime-db@>=1.12.0 <1.13.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
@@ -2298,113 +2371,113 @@
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
-                  "version": "1.4.7",
-                  "from": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-                  "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                  "version": "1.4.8",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                  "from": "qs@>=2.3.1 <2.4.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.3",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                  "from": "tough-cookie@>=0.12.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                      "from": "punycode@>=1.4.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
                     }
                   }
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "from": "ctype@0.5.3",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+                  "from": "oauth-sign@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "from": "hawk@1.1.1",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                      "from": "hoek@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                      "from": "boom@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                      "from": "sntp@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "from": "delayed-stream@0.0.5",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
@@ -2413,78 +2486,83 @@
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "from": "rimraf@>=2.2.8 <2.3.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "tar": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+              "from": "tar@>=1.0.3 <1.1.0",
               "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                  "from": "block-stream@*",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
             "which": {
               "version": "1.0.9",
-              "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+              "from": "which@>=1.0.8 <1.1.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             }
           }
         }
       }
     },
+    "limiter": {
+      "version": "1.1.2",
+      "from": "limiter@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz"
+    },
     "lines": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/lines/-/lines-1.0.1.tgz",
+      "from": "lines@1.0.1",
       "resolved": "https://registry.npmjs.org/lines/-/lines-1.0.1.tgz"
     },
     "moment": {
       "version": "2.16.0",
-      "from": "https://registry.npmjs.org/moment/-/moment-2.16.0.tgz",
+      "from": "moment@2.16.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.16.0.tgz"
     },
     "mongodb": {
       "version": "2.1.18",
-      "from": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
+      "from": "mongodb@2.1.18",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
       "dependencies": {
         "es6-promise": {
           "version": "3.0.2",
-          "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "from": "es6-promise@3.0.2",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
         },
         "mongodb-core": {
           "version": "1.3.18",
-          "from": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
+          "from": "mongodb-core@1.3.18",
           "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
           "dependencies": {
             "bson": {
               "version": "0.4.23",
-              "from": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+              "from": "bson@>=0.4.23 <0.5.0",
               "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
             },
             "require_optional": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+              "version": "1.0.1",
+              "from": "require_optional@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
               "dependencies": {
                 "semver": {
                   "version": "5.3.0",
-                  "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                  "from": "semver@>=5.1.0 <6.0.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                 },
                 "resolve-from": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                  "from": "resolve-from@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
                 }
               }
@@ -2493,27 +2571,27 @@
         },
         "readable-stream": {
           "version": "1.0.31",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+          "from": "readable-stream@1.0.31",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
@@ -2522,29 +2600,29 @@
     },
     "netmask": {
       "version": "0.0.2",
-      "from": "https://registry.npmjs.org/netmask/-/netmask-0.0.2.tgz",
+      "from": "netmask@0.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-0.0.2.tgz",
       "dependencies": {
         "coffee-script": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.2.0.tgz",
+          "from": "coffee-script@1.2.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.2.0.tgz"
         }
       }
     },
     "node-fs": {
       "version": "0.1.5",
-      "from": "https://registry.npmjs.org/node-fs/-/node-fs-0.1.5.tgz",
+      "from": "node-fs@0.1.5",
       "resolved": "https://registry.npmjs.org/node-fs/-/node-fs-0.1.5.tgz"
     },
     "optimist": {
       "version": "0.3.7",
-      "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+      "from": "optimist@0.3.7",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
-          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "from": "wordwrap@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
         }
       }
@@ -2560,9 +2638,9 @@
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
-          "version": "1.5.0",
+          "version": "1.6.0",
           "from": "aws4@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
         },
         "caseless": {
           "version": "0.11.0",
@@ -2582,9 +2660,9 @@
           }
         },
         "extend": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "extend@>=3.0.0 <3.1.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -2592,9 +2670,9 @@
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
-          "version": "2.1.2",
+          "version": "2.1.4",
           "from": "form-data@>=2.1.1 <2.2.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "dependencies": {
             "asynckit": {
               "version": "0.4.0",
@@ -2629,9 +2707,9 @@
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.0.0",
+                      "version": "2.1.1",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
@@ -2641,9 +2719,9 @@
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.0.0",
+                      "version": "2.1.1",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
@@ -2655,21 +2733,14 @@
               }
             },
             "commander": {
-              "version": "2.9.0",
+              "version": "2.11.0",
               "from": "commander@>=2.9.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
             },
             "is-my-json-valid": {
-              "version": "2.15.0",
+              "version": "2.16.0",
               "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -2752,10 +2823,15 @@
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
-              "version": "1.3.1",
+              "version": "1.4.0",
               "from": "jsprim@>=1.2.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
               "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                },
                 "extsprintf": {
                   "version": "1.0.2",
                   "from": "extsprintf@1.0.2",
@@ -2774,9 +2850,9 @@
               }
             },
             "sshpk": {
-              "version": "1.10.1",
+              "version": "1.13.1",
               "from": "sshpk@>=1.7.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
@@ -2794,24 +2870,19 @@
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                 },
                 "getpass": {
-                  "version": "0.1.6",
+                  "version": "0.1.7",
                   "from": "getpass@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
                 },
                 "jsbn": {
-                  "version": "0.1.0",
+                  "version": "0.1.1",
                   "from": "jsbn@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
                 },
                 "tweetnacl": {
                   "version": "0.14.5",
                   "from": "tweetnacl@>=0.14.0 <0.15.0",
                   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-                },
-                "jodid25519": {
-                  "version": "1.0.2",
-                  "from": "jodid25519@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
@@ -2819,9 +2890,9 @@
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 },
                 "bcrypt-pbkdf": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
                 }
               }
             }
@@ -2843,14 +2914,14 @@
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
-          "version": "2.1.13",
+          "version": "2.1.15",
           "from": "mime-types@>=2.1.7 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.25.0",
-              "from": "mime-db@>=1.25.0 <1.26.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
+              "version": "1.27.0",
+              "from": "mime-db@>=1.27.0 <1.28.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
             }
           }
         },
@@ -2860,9 +2931,9 @@
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
-          "version": "6.3.0",
+          "version": "6.3.2",
           "from": "qs@>=6.3.0 <6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
@@ -2887,20 +2958,20 @@
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         },
         "uuid": {
-          "version": "3.0.1",
+          "version": "3.1.0",
           "from": "uuid@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
         }
       }
     },
     "semver": {
       "version": "4.3.6",
-      "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+      "from": "semver@4.3.6",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
     },
     "underscore": {
       "version": "1.4.4",
-      "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "from": "underscore@1.4.4",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
     }
   }

--- a/fh-messaging/npm-shrinkwrap.json
+++ b/fh-messaging/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-messaging",
-  "version": "3.0.8-BUILD-NUMBER",
+  "version": "3.0.10-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.6",

--- a/fh-messaging/package.json
+++ b/fh-messaging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-messaging",
   "description": "FeedHenry Messaging Server",
-  "version": "3.0.9-BUILD-NUMBER",
+  "version": "3.0.10-BUILD-NUMBER",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-messaging.git"

--- a/fh-messaging/package.json
+++ b/fh-messaging/package.json
@@ -42,6 +42,7 @@
     "fh-health": "0.3.1",
     "fh-logger": "0.5.0",
     "geoip": "0.6.1",
+    "limiter": "~1.1.2",
     "lines": "1.0.1",
     "moment": "2.16.0",
     "mongodb": "2.1.18",

--- a/fh-messaging/sonar-project.properties
+++ b/fh-messaging/sonar-project.properties
@@ -1,3 +1,3 @@
 sonar.projectKey=fh-messaging
 sonar.projectName=fh-messaging-nightly-master
-sonar.projectVersion=3.0.8-BUILD-NUMBER
+sonar.projectVersion=3.0.10-BUILD-NUMBER

--- a/fh-messaging/test/integrate/test_fhsrv.js
+++ b/fh-messaging/test/integrate/test_fhsrv.js
@@ -674,6 +674,23 @@ exports.test_fhsrv_post_msg_too_large = function (test, assert) {
   });
 };
 
+exports.test_fhsrv_post_msg_topic_too_many_requests = function(test, assert) {
+  config.maxRequests = 0;
+  msgServer = new fhsrv.MessageServer(config, logger, function(err) {
+    assert.equal(err, null);
+
+    assert.response(msgServer.server, {
+      url: '/msg/log',
+      method: 'POST',
+      data: JSON.stringify(msgs2),
+      headers: helper.setDefaultHeaders(sendValidHeader, {})
+    }, function(res) {
+      assert.strictEqual(res.statusCode, 429, "expected statuscode 429 from /msg/tooManyRequests, but got: " + res.statusCode);
+      test.finish();
+    });
+  });
+};
+
 //######################## INVALID TESTS END ########################
 
 // Test that posting rolled-up metrics for domain will lead into creating 2 records in collection

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.2.2",
   "dependencies": {
     "moment": {
-      "version": "2.15.2",
+      "version": "2.18.1",
       "from": "moment@>=2.10.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.2.tgz"
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz"
     }
   }
 }


### PR DESCRIPTION
## Motivation
When/if a customers app produces excessive logging in fh-messaging, this will result in associated high load and volume space exhaustion in the mongo servers within the core.

## Result
There is already rate limiting being applied to this [endpoint](https://github.com/feedhenry/fh-messaging/blob/master/fh-messaging/lib/fhsrv.js#L179). When a request is made a batch limit and an interval is set on the request [here](https://github.com/feedhenry/fh-reportingclient/blob/master/lib/mbaas-reporting.js#L3) so the issue was not the amount of requests made to the this endpoint but the amount of documents being logged per request. 
To prevent the mongo servers from "flooding", there is a rate limit implemented for the documents (messages) being inserted into mongo per request.

## Jira
https://issues.jboss.org/browse/RHMAP-16416