### PR TITLE
RHMAP-16710 - reclaim the disk space from mongodb after cleaning up t…

### DIFF
--- a/fh-messaging/Gruntfile.js
+++ b/fh-messaging/Gruntfile.js
@@ -7,6 +7,7 @@ module.exports = function(grunt) {
     _unit_tests: [
       'test/handlers/test_receive_rolled_up_metrics.js',
       'test/jobs/test_metrics_rollup_job.js',
+      'test/jobs/test_metrics_prune_job.js',
       'test/unit/mongo_functions/test_metrics_domain.js',
       'test/unit/mongo_functions/test_metrics_geo.js',
       'test/unit/mongo_functions/test_metrics_geo_domain.js',

--- a/fh-messaging/config/dev.json
+++ b/fh-messaging/config/dev.json
@@ -13,6 +13,9 @@
           },
           "doImport":false
         }
+      },
+      "metrics_prune_job": {
+        "schedule": "10 2 * * 7"
       }
     }
   },

--- a/fh-messaging/lib/jobs/metrics_prune_job.js
+++ b/fh-messaging/lib/jobs/metrics_prune_job.js
@@ -1,0 +1,41 @@
+var util = require('util');
+
+module.exports = function(logger, config, agenda, db) {
+  var logTag = "#metrics_prune";
+  var jobSchedule = config.agenda.jobs.metrics_prune_job.schedule;
+  var jobName = "metrics_prune_job";
+
+  return {
+    "setUp": jobSetup
+  };
+
+  function jobSetup() {
+    agenda.define(jobName, jobDefinition(db));
+    agenda.every(jobSchedule, 'metrics_prune_job', {}, { "timezone": "UTC" });
+
+    agenda.on("fail:metrics_prune_job", function(err, job) {
+      if (job.audit) {
+        job.audit.completeJobWithError("agenda job failed ", err);
+      }
+      logger.warn(logTag + " : failed  to run job metrics_prune_job error " + util.inspect(err));
+    });
+  }
+
+  function jobDefinition(db) {
+    return function(job, done) {
+      try {
+        db.command({ repairDatabase: 1 }, function(err) {
+          if (err) {
+            logger.error("failed to free up disk space" + err);
+            return done(err);
+          } else {
+            logger.info("reclaimed disk space ");
+            done();
+          }
+        });
+      } catch (e) {
+        logger.error(logTag + "exception occurred running job ", e);
+      }
+    };
+  }
+};

--- a/fh-messaging/npm-shrinkwrap.json
+++ b/fh-messaging/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-messaging",
-  "version": "3.0.7-BUILD-NUMBER",
+  "version": "3.0.8-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.6",

--- a/fh-messaging/package.json
+++ b/fh-messaging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-messaging",
   "description": "FeedHenry Messaging Server",
-  "version": "3.0.7-BUILD-NUMBER",
+  "version": "3.0.8-BUILD-NUMBER",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-messaging.git"

--- a/fh-messaging/sonar-project.properties
+++ b/fh-messaging/sonar-project.properties
@@ -1,3 +1,3 @@
 sonar.projectKey=fh-messaging
 sonar.projectName=fh-messaging-nightly-master
-sonar.projectVersion=3.0.7-BUILD-NUMBER
+sonar.projectVersion=3.0.8-BUILD-NUMBER

--- a/fh-messaging/test/jobs/test_metrics_prune_job.js
+++ b/fh-messaging/test/jobs/test_metrics_prune_job.js
@@ -1,0 +1,44 @@
+var sinon = require('sinon');
+var fhlogger = require('fh-logger');
+var metricsPruneJob = require('../../lib/jobs/metrics_prune_job');
+
+var mockAgenda, config, logger;
+var db = {
+  command: function() {}
+};
+
+exports.setUp = function(setUp, assert) {
+  mockAgenda = {
+    define: sinon.spy(function(jobName) {
+      assert.equal(jobName, 'metrics_prune_job');
+    }),
+    every: sinon.spy(function(schedule, jobName) {
+      assert.equal(jobName, 'metrics_prune_job');
+    }),
+    "on": function() {}
+  };
+
+  config = {
+    agenda: {
+      jobs: {
+        metrics_prune_job: {
+          schedule: '1 minute'
+        }
+      }
+    }
+  };
+
+  logger = fhlogger.createLogger({ name: 'test_metrics_prune_job' });
+  setUp.finish();
+};
+
+exports.test_job_setup = function(test, assert) {
+  var job = metricsPruneJob(logger, config, mockAgenda, db);
+  job.setUp();
+
+  assert.ok(mockAgenda.define.called);
+  assert.ok(mockAgenda.every.called);
+
+  test.finish();
+
+};


### PR DESCRIPTION
…he collections

## Motivation
The `metrics_rollup_job` was removing metric data out of the mongo database but the disk space was not being reclaimed.

## Result
Add a job to the agenda scheduler that runs `repairDatabase`  once a week (at 2:10 a.m. every Sunday) on the mongo database which will free up disk space.


Note: 

- in order for  `repairDatabase` to work it requires free disk space equal to the size of your current data set plus 2 gigabytes.  So this job may not always work.
- this new job will be configurable

## Jira
https://issues.jboss.org/browse/RHMAP-16710