### PR TITLE
Bump

### DIFF
--- a/fh-messaging/package.json
+++ b/fh-messaging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-messaging",
   "description": "FeedHenry Messaging Server",
-  "version": "3.0.8-BUILD-NUMBER",
+  "version": "3.0.9-BUILD-NUMBER",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-messaging.git"

--- a/fh-metrics/package.json
+++ b/fh-metrics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-metrics",
   "description": "FeedHenry Metrics Server",
-  "version": "3.0.6-BUILD-NUMBER",
+  "version": "3.0.7-BUILD-NUMBER",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-messaging.git"


### PR DESCRIPTION
re: https://github.com/feedhenry/fh-messaging/pull/23

Rebuilding with a bump after updating RHEL slave's Docker version from `1.9.1` (ancient) to `1.12.6` in an attempt to fix `System error: read parent: connection reset by peer` errors we've been seeing. Some googling[1] pointed to an out-of-date version of docker

@rachael-oregan FYI

[1] https://github.com/moby/moby/issues/14203