### PR TITLE
Rhmap 17058

### DIFF
--- a/fh-metrics/lib/fhmetricssrv.js
+++ b/fh-metrics/lib/fhmetricssrv.js
@@ -112,7 +112,17 @@ var getMetric = function(metric, metric_id_field_name, query, callback) {
   logger.info('METRIC_collection: ' + metricCollection + ' ' + metric_id_field_name + ': ' + query._id);
 
   var findQuery = {'_id.ts': {$gte: startDate.getTime(), $lt: endDate.getTime()} };
-  findQuery[metric_id_field_name] = query._id;
+
+  // The _id field can be an array for service requests (containing all the ids of the
+  // associated services
+  if (query._id && Array.isArray(query._id)) {
+    findQuery[metric_id_field_name] = {
+      $in: query._id
+    };
+  } else {
+    findQuery[metric_id_field_name] = query._id;
+  }
+
   logger.info('METRIC_QUERY: ' + JSON.stringify(findQuery));
   messaging.database.find(metricCollection, findQuery, function(err, results) {
     if (err) {

--- a/fh-metrics/npm-shrinkwrap.json
+++ b/fh-metrics/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-metrics",
-  "version": "3.0.6-BUILD-NUMBER",
+  "version": "3.0.8-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "1.5.2",

--- a/fh-metrics/package.json
+++ b/fh-metrics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-metrics",
   "description": "FeedHenry Metrics Server",
-  "version": "3.0.7-BUILD-NUMBER",
+  "version": "3.0.8-BUILD-NUMBER",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-messaging.git"

--- a/fh-metrics/sonar-project.properties
+++ b/fh-metrics/sonar-project.properties
@@ -1,3 +1,3 @@
 sonar.projectKey=fh-metrics
 sonar.projectName=fh-metrics-nightly-master
-sonar.projectVersion=3.0.6-BUILD-NUMBER
+sonar.projectVersion=3.0.8-BUILD-NUMBER


### PR DESCRIPTION
Extend the metrics server so that it also accepts guid arrays (this is needed for Service Metrics: we want to query the data for all associated services in one go)