### PR TITLE
Prune collections in fh-messaging

### DIFF
--- a/fh-messaging/lib/helpers.js
+++ b/fh-messaging/lib/helpers.js
@@ -222,6 +222,21 @@ function daysAgoFromDate(date, daysAgo) {
   };
 }
 
+function toDateFromYYYYMMDD( date_name ) {
+  // get the date from the YYYYMMDD
+  // get the YYYY substring
+  var year = date_name.substring(0,4);
+  // get the MM substring
+  // month is 0 indexed
+  var month = date_name.substring(4,6) - 1;
+  // get the DD substring
+  var day = date_name.substring(6, date_name.length);
+
+  // construct and return a Date
+  return new Date(year, month, day);
+}
+
+exports.toDateFromYYYYMMDD = toDateFromYYYYMMDD;
 exports.constructCollectionName = constructCollectionName;
 exports.isWhiteListed = isWhiteListed;
 exports.getCollectionNameFromTopicAndId = getCollectionNameFromTopicAndId;

--- a/fh-messaging/npm-shrinkwrap.json
+++ b/fh-messaging/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-messaging",
-  "version": "3.2.0-BUILD-NUMBER",
+  "version": "3.3.0-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.6",

--- a/fh-messaging/package.json
+++ b/fh-messaging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-messaging",
   "description": "FeedHenry Messaging Server",
-  "version": "3.2.0-BUILD-NUMBER",
+  "version": "3.3.0-BUILD-NUMBER",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-messaging.git"

--- a/fh-messaging/sonar-project.properties
+++ b/fh-messaging/sonar-project.properties
@@ -1,3 +1,3 @@
 sonar.projectKey=fh-messaging
 sonar.projectName=fh-messaging-nightly-master
-sonar.projectVersion=3.2.0-BUILD-NUMBER
+sonar.projectVersion=3.3.0-BUILD-NUMBER

--- a/fh-messaging/test/integrate/test_fh_metrics_man_gen_metrics.js
+++ b/fh-messaging/test/integrate/test_fh_metrics_man_gen_metrics.js
@@ -34,6 +34,18 @@ exports.setUp = function (test, assert) {
   logger.info("Test metrics dir :: " + config.metrics.metricsDir);
 
   testData = {
+    "fhact_20110101":{
+      "index": "MD5",
+      "data": [
+        {}
+      ]
+    },
+    "fhact_30000101":{
+      "index": "MD5",
+      "data": [
+        {}
+      ]
+    },
     "appinit_20110612": {
       "index": 'MD5',
       "data": [
@@ -119,6 +131,39 @@ exports.tearDown = function (test, assert) {
     test.finish();
   });
 };
+
+
+exports.test_deleteMetricsData = function (test, assert) {
+  var topic = 'fhact'; // get the list of topics that this is generally run for
+  logger.info("Running deleteMetricsData for: " + topic);
+  var date = new Date();
+  var results = [{name: 'appinit_20110612', options: {}},{name: 'appinit_20110613', options: {}},{name: 'fhact_30000101', options: {}}];
+
+  metricsMan = new fhmm.MetricsManager(config, logger);
+
+  metricsMan.deleteMetricsData(topic, date, function (err, metricsMan_db) {
+    assert.ok(!err);
+
+    async.series([
+      function (testCallback){
+        metricsMan_db.listCollections({}).toArray(function(err, items){
+          if(err){
+            logger.error(err);
+          }
+
+          assert.ok(!err);
+          assert.equal(3, items.length);
+          assert.equal(results.toString(), items.toString());
+
+          testCallback();
+        });
+      }
+    ], function (err, res) {
+      test.finish();
+    });
+  });
+}
+
 
 exports.test_generateMetricsData_day1 = function (test, assert) {
   var topic = 'appinit';


### PR DESCRIPTION
## Jira link's
https://issues.jboss.org/browse/RHMAP-19375

## What
In cases where the fh-messaging pruning job fails on a particular day, we can end up with situations where the collections are then not pruned and live on forever or until manual intervention by FHOPS is undertaken.

## Why
Reason : FHOPS needs this fix in place, as it is currently taking manual intervention to clean up after the platform. The current fix for this is:
- FHOPS engineer manually logging into each mongo database primary in each core and each mbaas
- accessing the fh-messaging database
- manually dropping collections which are older than 31 days
- placing customer data at great risk due to mistakes made via this manual process.

## How
The pruning job will now also run for the previous day also, each time it is executed.

#### Info
- The fh-messaging configuration **metrics\_rollup\_job daysToKeep** defaults to `31` days in production
- fh-messaging uses the **fh-reporting** database in Mongo.
- The admin password can be retrieved from the **mongodb-admin-password** key inside the **mongodb-keys** config-map.

#### Verification
- Deploy changes to a cluster.
- Connect to the Mongo primary pod in the replica set in the Core|MBaaS project. eg: `oc rsh mongodb-1-1-wt99t`
- Launch the mongo client: `mongo 127.0.0.1/admin -u admin -p $MONGODB_ADMIN_PASSWORD`
- `use fh-reporting` use the database
- `show collections` list the collections, and make note of the **fhact_yyyymmdd** collections
- Connect to one of the fh-messaging pods
- Run the pruning command `bash bin/fh-msg-process $(date '+%F') NO_IMPORT config`
- `show collections` once more on the Mongo replica primary. And make note of the **fhact_yyyymmdd** collections. Collections from dates more than 31 days ago should no longer be listed.
