### PR TITLE
Rhmap 20884

### DIFF
--- a/fh-messaging/Dockerfile.dev
+++ b/fh-messaging/Dockerfile.dev
@@ -16,12 +16,14 @@ RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime && \
 
 USER default
 
-RUN scl enable rh-nodejs4 "npm install -g nodemon" && \
-    scl enable rh-nodejs4 "npm install --production" && \
+RUN scl enable rh-nodejs6 "npm install -g forever" && \
+    scl enable rh-nodejs6 "npm install --production" && \
     mv conf-docker.json config/conf.json && \
     chmod -R ug+rw ./ && \
     cp lib/shell/processone.sh bin/fh-msg-process \
     && cp bin/fh_metrics_cli.js bin/fh-metrics-cli
+
+RUN echo "node_modules" >> .foreverignore
 
 USER root
 RUN  mkdir -p /root/licenses/rhmap/ && \
@@ -30,4 +32,4 @@ USER default
 
 ENV FHDEV true
 
-CMD ["bash", "-c", "nodemon --debug=5858 ./bin/fhmsgsrv.js ./config/conf.json --master-only"]
+CMD ["forever","-w","--watchDirectory=/opt/app-root/src", "-c", "node --debug", "bin/fhmsgsrv.js","config/conf.json","--master-only"]

--- a/fh-messaging/README.md
+++ b/fh-messaging/README.md
@@ -102,15 +102,16 @@ For development purposes, we can build a CentOS based Docker image and watch for
 ### Build the development image
 1. Generate the config file: `grunt fh-generate-dockerised-config`
 2. `docker build -t docker.io/my-Username/fh-messaging:dev -f Dockerfile.dev .`
-3. `oc edit dc fh-messaging`
-4. Replace the image with the tagged version above.
+3. `docker push docker.io/my-Username/fh-messaging:dev`
+4. `oc edit dc fh-messaging`
+5. Replace the image with the tagged version above.
 
 ### Hot Deployment
 
 The development image will allow you to sync local code changes to the running container without the need for rebuilding or redeploying the image.
 
 From the root of the `fh-messaging directory, run the following:
-```oc rsync --no-perms=true ./lib $(oc get po | grep fh-messaging | grep Running | awk '{print $1}'):/opt/app-root/src ```
+```oc rsync --watch --no-perms=true ./lib $(oc get po | grep fh-messaging | grep Running | awk '{print $1}'):/opt/app-root/src ```
 
 ### Debugging with VS Code
 

--- a/fh-metrics/Dockerfile.dev
+++ b/fh-metrics/Dockerfile.dev
@@ -16,10 +16,12 @@ RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime && \
 
 USER default
 
-RUN scl enable rh-nodejs4 "npm install -g nodemon" && \
-    scl enable rh-nodejs4 "npm install --production" && \
+RUN scl enable rh-nodejs6 "npm install -g forever" && \
+    scl enable rh-nodejs6 "npm install --production" && \
     mv conf-docker.json config/conf.json && \
     chmod -R ug+rw ./
+
+RUN echo "node_modules" >> .foreverignore
 
 USER root
 RUN  mkdir -p /root/licenses/rhmap/ && \
@@ -28,4 +30,4 @@ USER default
 
 ENV FHDEV true
 
-CMD ["bash", "-c", "nodemon --debug=5858 bin/fhmetsrv.js config/conf.json --master-only"]
+CMD ["forever","-w","--watchDirectory=/opt/app-root/src", "-c", "node --debug", "bin/fhmetsrv.js","config/conf.json","--master-only"]

--- a/fh-metrics/README.md
+++ b/fh-metrics/README.md
@@ -119,15 +119,16 @@ For development purposes, we can build a CentOS based Docker image and watch for
 ### Build the development image
 1. Generate the config file: `grunt fh-generate-dockerised-config`
 2. `docker build -t docker.io/my-Username/fh-metrics:dev -f Dockerfile.dev .`
-3. `oc edit dc fh-metrics`
-4. Replace the image with the tagged version above.
+3. `docker push docker.io/my-Username/fh-metrics:dev`
+4. `oc edit dc fh-metrics`
+5. Replace the image with the tagged version above.
 
 ### Hot Deployment
 
 The development image will allow you to sync local code changes to the running container without the need for rebuilding or redeploying the image.
 
 From the root of the `fh-metrics directory, run the following:
-```oc rsync --no-perms=true ./lib $(oc get po | grep fh-metrics | grep Running | awk '{print $1}'):/opt/app-root/src ```
+```oc rsync --watch --no-perms=true ./lib $(oc get po | grep fh-metrics | grep Running | awk '{print $1}'):/opt/app-root/src ```
 
 ### Debugging with VS Code
 


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-20884
https://issues.jboss.org/browse/RHMAP-20593


# What
Update Dockerfile.dev to use forever npm
Fixing the CMD in the Dockerfile.dev to run this component in debug mode. 


# Why
Having the component run in debug mode allows us to attach a remote debugger (e.g. from VS Code).


# How
When using the forever module, running node in debug mode requires the command to be specified like so `-c "node --debug"`


# Verification Steps
1. Go to https://csteam1.skunkhenry.com:8443/console/project/rhmap-core/browse/pods/fh-messaging-2-xg9l4?tab=logs
3. Verify that the top of the logs says `Debugger listening on [::]:5858`
2. Go to https://csteam1.skunkhenry.com:8443/console/project/rhmap-core/browse/pods/fh-metrics-2-tpjlr?tab=logs
3. Verify that the top of the logs says `Debugger listening on [::]:5858`
2. Go to https://csteam1.skunkhenry.com:8443/console/project/rhmap-3-node-mbaas/browse/pods/fh-messaging-2-xg6qh?tab=logs
3. Verify that the top of the logs says `Debugger listening on [::]:5858`
2. Go to https://csteam1.skunkhenry.com:8443/console/project/rhmap-3-node-mbaas/browse/pods/fh-metrics-2-4459n?tab=logs
3. Verify that the top of the logs says `Debugger listening on [::]:5858`


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 