### PR TITLE
fix(Unable to find IP geolocation): Upgrade version of the geoip-lite from ~1.0.5 to  1.3.1

### DIFF
--- a/fh-messaging/npm-shrinkwrap.json
+++ b/fh-messaging/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-messaging",
-  "version": "3.3.1-BUILD-NUMBER",
+  "version": "3.3.2-BUILD-NUMBER",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fh-messaging/npm-shrinkwrap.json
+++ b/fh-messaging/npm-shrinkwrap.json
@@ -9,21 +9,26 @@
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.6.tgz",
       "integrity": "sha1-rT83PZJJrjJIgVZVgryQ4VKrvWg="
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
     "body-parser": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "bytes": {
@@ -64,7 +69,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.3.1 < 2"
           },
           "dependencies": {
             "depd": {
@@ -138,7 +143,7 @@
           "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.17"
+            "mime-types": "~2.1.15"
           },
           "dependencies": {
             "media-typer": {
@@ -151,7 +156,7 @@
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
               "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
               "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -165,46 +170,89 @@
         }
       }
     },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "colors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+      "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
     "countries-list": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/countries-list/-/countries-list-1.4.1.tgz",
       "integrity": "sha1-R+JU/WD1NmDUstGUrhF/qTjqfCk="
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
     },
     "express": {
       "version": "4.16.0",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.0.tgz",
       "integrity": "sha1-tRljjk61jnF4yBtJjvIveYyy4lU=",
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
+        "proxy-addr": "~2.0.2",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.0",
         "serve-static": "1.13.0",
         "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "accepts": {
@@ -212,7 +260,7 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
           "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
           "requires": {
-            "mime-types": "2.1.17",
+            "mime-types": "~2.1.16",
             "negotiator": "0.6.1"
           },
           "dependencies": {
@@ -221,7 +269,7 @@
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
               "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
               "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -304,12 +352,12 @@
           "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.3.1",
+            "unpipe": "~1.0.0"
           },
           "dependencies": {
             "unpipe": {
@@ -364,7 +412,7 @@
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
           "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
           "requires": {
-            "forwarded": "0.1.2",
+            "forwarded": "~0.1.2",
             "ipaddr.js": "1.5.2"
           },
           "dependencies": {
@@ -401,18 +449,18 @@
           "integrity": "sha1-FjONu5ou3krVe0hCDsO4LY6ApXs=",
           "requires": {
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.1",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.2",
+            "http-errors": "~1.6.2",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.3.1"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.3.1"
           },
           "dependencies": {
             "destroy": {
@@ -428,7 +476,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": "1.3.1"
+                "statuses": ">= 1.3.1 < 2"
               },
               "dependencies": {
                 "depd": {
@@ -465,9 +513,9 @@
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.0.tgz",
           "integrity": "sha1-gQyR24AOlLoofq5rTgbKq5/cFvE=",
           "requires": {
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.2",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.2",
             "send": "0.16.0"
           }
         },
@@ -487,7 +535,7 @@
           "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.17"
+            "mime-types": "~2.1.15"
           },
           "dependencies": {
             "media-typer": {
@@ -500,7 +548,7 @@
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
               "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
               "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -529,11 +577,11 @@
       "resolved": "https://registry.npmjs.org/express-bunyan-logger/-/express-bunyan-logger-1.3.1.tgz",
       "integrity": "sha1-Nu5mu89YDzCFvGoAP1W4Qhu8JGA=",
       "requires": {
-        "bunyan": "1.8.12",
-        "lodash.has": "4.5.2",
-        "lodash.set": "4.3.2",
-        "node-uuid": "1.4.8",
-        "useragent": "2.3.0"
+        "bunyan": "^1.8.1",
+        "lodash.has": "^4.5.1",
+        "lodash.set": "^4.3.1",
+        "node-uuid": "^1.4.7",
+        "useragent": "^2.1.9"
       },
       "dependencies": {
         "bunyan": {
@@ -541,10 +589,10 @@
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
           "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
           "requires": {
-            "dtrace-provider": "0.8.6",
-            "moment": "2.19.3",
-            "mv": "2.1.1",
-            "safe-json-stringify": "1.0.4"
+            "dtrace-provider": "~0.8",
+            "moment": "^2.10.6",
+            "mv": "~2",
+            "safe-json-stringify": "~1"
           },
           "dependencies": {
             "dtrace-provider": {
@@ -553,7 +601,7 @@
               "integrity": "sha1-QooiOv4DQl0s1tY0f99AxmkDVj0=",
               "optional": true,
               "requires": {
-                "nan": "2.8.0"
+                "nan": "^2.3.3"
               },
               "dependencies": {
                 "nan": {
@@ -570,9 +618,9 @@
               "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
               "optional": true,
               "requires": {
-                "mkdirp": "0.5.1",
-                "ncp": "2.0.0",
-                "rimraf": "2.4.5"
+                "mkdirp": "~0.5.1",
+                "ncp": "~2.0.0",
+                "rimraf": "~2.4.0"
               },
               "dependencies": {
                 "mkdirp": {
@@ -604,7 +652,7 @@
                   "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                   "optional": true,
                   "requires": {
-                    "glob": "6.0.4"
+                    "glob": "^6.0.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -613,11 +661,11 @@
                       "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                       "optional": true,
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -626,8 +674,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "optional": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -650,7 +698,7 @@
                           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                           "optional": true,
                           "requires": {
-                            "brace-expansion": "1.1.8"
+                            "brace-expansion": "^1.1.7"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -659,7 +707,7 @@
                               "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                               "optional": true,
                               "requires": {
-                                "balanced-match": "1.0.0",
+                                "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -684,7 +732,7 @@
                           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -734,8 +782,8 @@
           "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
           "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
           "requires": {
-            "lru-cache": "4.1.1",
-            "tmp": "0.0.33"
+            "lru-cache": "4.1.x",
+            "tmp": "0.0.x"
           },
           "dependencies": {
             "lru-cache": {
@@ -743,8 +791,8 @@
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
               "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
               "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
               },
               "dependencies": {
                 "pseudomap": {
@@ -764,7 +812,7 @@
               "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
               "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
               "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
               },
               "dependencies": {
                 "os-tmpdir": {
@@ -778,15 +826,23 @@
         }
       }
     },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
     "fh-agenda": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/fh-agenda/-/fh-agenda-0.9.0.tgz",
       "integrity": "sha1-qlfCZfiRzK9gka9fChD1Hh0M+JI=",
       "requires": {
-        "cron": "1.1.1",
-        "date.js": "0.3.2",
-        "human-interval": "0.1.6",
-        "moment-timezone": "0.5.14",
+        "cron": "~1.1.0",
+        "date.js": "~0.3.1",
+        "human-interval": "~0.1.3",
+        "moment-timezone": "^0.5.0",
         "mongodb": "2.1.11"
       },
       "dependencies": {
@@ -795,7 +851,7 @@
           "resolved": "https://registry.npmjs.org/cron/-/cron-1.1.1.tgz",
           "integrity": "sha1-AnGdTvSA38juJNgaNgNGC6OQE84=",
           "requires": {
-            "moment-timezone": "0.5.14"
+            "moment-timezone": "~0.5.5"
           }
         },
         "date.js": {
@@ -803,7 +859,7 @@
           "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.2.tgz",
           "integrity": "sha512-wCedqqkYrduV8nH+OftEdGZzsJGgZ6tj1c1YNhcsrdysE0b0YzHzAeo1P83FICx1ULsuDsTFDHxyFBch/Ec2kg==",
           "requires": {
-            "debug": "3.1.0"
+            "debug": "~3.1.0"
           },
           "dependencies": {
             "debug": {
@@ -833,7 +889,7 @@
           "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
           "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
           "requires": {
-            "moment": "2.19.3"
+            "moment": ">= 2.9.0"
           }
         },
         "mongodb": {
@@ -856,8 +912,8 @@
               "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.10.tgz",
               "integrity": "sha1-Ud3Ov56c/9BX+C8pI82qwGzzIBs=",
               "requires": {
-                "bson": "0.4.23",
-                "require_optional": "1.0.1"
+                "bson": "~0.4.21",
+                "require_optional": "~1.0.0"
               },
               "dependencies": {
                 "bson": {
@@ -870,8 +926,8 @@
                   "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
                   "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
                   "requires": {
-                    "resolve-from": "2.0.0",
-                    "semver": "5.5.0"
+                    "resolve-from": "^2.0.0",
+                    "semver": "^5.1.0"
                   },
                   "dependencies": {
                     "resolve-from": {
@@ -893,10 +949,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
               "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               },
               "dependencies": {
                 "core-util-is": {
@@ -930,25 +986,28 @@
       "resolved": "https://registry.npmjs.org/fh-cluster/-/fh-cluster-0.3.0.tgz",
       "integrity": "sha1-Z8YOK1+ftMfueb556IzkN+NAK7I=",
       "requires": {
-        "backoff": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        "backoff": "2.4.1",
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "backoff": {
-          "version": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
           "integrity": "sha512-gd7froKGnmDsq2IczAXNLMQO6GXuqU6UUGlbo/R6MlaTmqFUozc7Ny3f5vRbcRwAK//lc0/hpaOKO7AP8zAv/Q==",
           "requires": {
-            "precond": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
+            "precond": "0.2"
           },
           "dependencies": {
             "precond": {
-              "version": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
               "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ=="
             }
           }
         },
         "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="
         }
       }
@@ -958,11 +1017,11 @@
       "resolved": "https://registry.npmjs.org/fh-config/-/fh-config-1.0.3.tgz",
       "integrity": "sha1-GWqhOEE8LG60jVH/AuUbsVkIFO4=",
       "requires": {
-        "async": "0.9.2",
-        "bunyan": "1.8.4",
-        "dateformat": "1.0.12",
-        "underscore": "1.8.3",
-        "winston": "0.8.3"
+        "async": "^0.9.0",
+        "bunyan": "^1.1.3",
+        "dateformat": "^1.0.8",
+        "underscore": "^1.8.3",
+        "winston": "^0.8.1"
       },
       "dependencies": {
         "async": {
@@ -975,10 +1034,10 @@
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.4.tgz",
           "integrity": "sha1-mAE6zIEuvDgGNkBJ7fbJEp2LjXM=",
           "requires": {
-            "dtrace-provider": "0.7.1",
-            "moment": "2.15.2",
-            "mv": "2.1.1",
-            "safe-json-stringify": "1.0.3"
+            "dtrace-provider": "~0.7",
+            "moment": "^2.10.6",
+            "mv": "~2",
+            "safe-json-stringify": "~1"
           },
           "dependencies": {
             "dtrace-provider": {
@@ -987,7 +1046,7 @@
               "integrity": "sha1-wGswjy8Q1dWDiuycVx5dWI3HHQQ=",
               "optional": true,
               "requires": {
-                "nan": "2.4.0"
+                "nan": "^2.3.3"
               },
               "dependencies": {
                 "nan": {
@@ -1010,9 +1069,9 @@
               "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
               "optional": true,
               "requires": {
-                "mkdirp": "0.5.1",
-                "ncp": "2.0.0",
-                "rimraf": "2.4.5"
+                "mkdirp": "~0.5.1",
+                "ncp": "~2.0.0",
+                "rimraf": "~2.4.0"
               },
               "dependencies": {
                 "mkdirp": {
@@ -1044,7 +1103,7 @@
                   "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                   "optional": true,
                   "requires": {
-                    "glob": "6.0.4"
+                    "glob": "^6.0.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -1053,11 +1112,11 @@
                       "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                       "optional": true,
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -1066,8 +1125,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "optional": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -1090,7 +1149,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "optional": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -1099,7 +1158,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "optional": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -1124,7 +1183,7 @@
                           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -1159,8 +1218,8 @@
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "get-stdin": "^4.0.1",
+            "meow": "^3.3.0"
           },
           "dependencies": {
             "get-stdin": {
@@ -1173,16 +1232,16 @@
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
               "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
               "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.3.5",
-                "object-assign": "4.1.0",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
               },
               "dependencies": {
                 "camelcase-keys": {
@@ -1190,8 +1249,8 @@
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                   "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
                   "requires": {
-                    "camelcase": "2.1.1",
-                    "map-obj": "1.0.1"
+                    "camelcase": "^2.0.0",
+                    "map-obj": "^1.0.0"
                   },
                   "dependencies": {
                     "camelcase": {
@@ -1211,8 +1270,8 @@
                   "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
                   "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
                   "requires": {
-                    "currently-unhandled": "0.4.1",
-                    "signal-exit": "3.0.1"
+                    "currently-unhandled": "^0.4.1",
+                    "signal-exit": "^3.0.0"
                   },
                   "dependencies": {
                     "currently-unhandled": {
@@ -1220,7 +1279,7 @@
                       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
                       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
                       "requires": {
-                        "array-find-index": "1.0.2"
+                        "array-find-index": "^1.0.1"
                       },
                       "dependencies": {
                         "array-find-index": {
@@ -1252,10 +1311,10 @@
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
                   "requires": {
-                    "hosted-git-info": "2.1.5",
-                    "is-builtin-module": "1.0.0",
-                    "semver": "5.3.0",
-                    "validate-npm-package-license": "3.0.1"
+                    "hosted-git-info": "^2.1.4",
+                    "is-builtin-module": "^1.0.0",
+                    "semver": "2 || 3 || 4 || 5",
+                    "validate-npm-package-license": "^3.0.1"
                   },
                   "dependencies": {
                     "hosted-git-info": {
@@ -1268,7 +1327,7 @@
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                       "requires": {
-                        "builtin-modules": "1.1.1"
+                        "builtin-modules": "^1.0.0"
                       },
                       "dependencies": {
                         "builtin-modules": {
@@ -1288,8 +1347,8 @@
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
                       "requires": {
-                        "spdx-correct": "1.0.2",
-                        "spdx-expression-parse": "1.0.4"
+                        "spdx-correct": "~1.0.0",
+                        "spdx-expression-parse": "~1.0.0"
                       },
                       "dependencies": {
                         "spdx-correct": {
@@ -1297,7 +1356,7 @@
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                           "requires": {
-                            "spdx-license-ids": "1.2.2"
+                            "spdx-license-ids": "^1.0.2"
                           },
                           "dependencies": {
                             "spdx-license-ids": {
@@ -1326,8 +1385,8 @@
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                   "requires": {
-                    "find-up": "1.1.2",
-                    "read-pkg": "1.1.0"
+                    "find-up": "^1.0.0",
+                    "read-pkg": "^1.0.0"
                   },
                   "dependencies": {
                     "find-up": {
@@ -1335,8 +1394,8 @@
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                       "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                       },
                       "dependencies": {
                         "path-exists": {
@@ -1344,7 +1403,7 @@
                           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                           "requires": {
-                            "pinkie-promise": "2.0.1"
+                            "pinkie-promise": "^2.0.0"
                           }
                         },
                         "pinkie-promise": {
@@ -1352,7 +1411,7 @@
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "requires": {
-                            "pinkie": "2.0.4"
+                            "pinkie": "^2.0.0"
                           },
                           "dependencies": {
                             "pinkie": {
@@ -1369,9 +1428,9 @@
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                       "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.3.5",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                       },
                       "dependencies": {
                         "load-json-file": {
@@ -1379,11 +1438,11 @@
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                           "requires": {
-                            "graceful-fs": "4.1.9",
-                            "parse-json": "2.2.0",
-                            "pify": "2.3.0",
-                            "pinkie-promise": "2.0.1",
-                            "strip-bom": "2.0.0"
+                            "graceful-fs": "^4.1.2",
+                            "parse-json": "^2.2.0",
+                            "pify": "^2.0.0",
+                            "pinkie-promise": "^2.0.0",
+                            "strip-bom": "^2.0.0"
                           },
                           "dependencies": {
                             "graceful-fs": {
@@ -1396,7 +1455,7 @@
                               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                               "requires": {
-                                "error-ex": "1.3.0"
+                                "error-ex": "^1.2.0"
                               },
                               "dependencies": {
                                 "error-ex": {
@@ -1404,7 +1463,7 @@
                                   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                   "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
                                   "requires": {
-                                    "is-arrayish": "0.2.1"
+                                    "is-arrayish": "^0.2.1"
                                   },
                                   "dependencies": {
                                     "is-arrayish": {
@@ -1426,7 +1485,7 @@
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                               "requires": {
-                                "pinkie": "2.0.4"
+                                "pinkie": "^2.0.0"
                               },
                               "dependencies": {
                                 "pinkie": {
@@ -1441,7 +1500,7 @@
                               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                               "requires": {
-                                "is-utf8": "0.2.1"
+                                "is-utf8": "^0.2.0"
                               },
                               "dependencies": {
                                 "is-utf8": {
@@ -1458,9 +1517,9 @@
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                           "requires": {
-                            "graceful-fs": "4.1.9",
-                            "pify": "2.3.0",
-                            "pinkie-promise": "2.0.1"
+                            "graceful-fs": "^4.1.2",
+                            "pify": "^2.0.0",
+                            "pinkie-promise": "^2.0.0"
                           },
                           "dependencies": {
                             "graceful-fs": {
@@ -1478,7 +1537,7 @@
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                               "requires": {
-                                "pinkie": "2.0.4"
+                                "pinkie": "^2.0.0"
                               },
                               "dependencies": {
                                 "pinkie": {
@@ -1499,8 +1558,8 @@
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
                   "requires": {
-                    "indent-string": "2.1.0",
-                    "strip-indent": "1.0.1"
+                    "indent-string": "^2.1.0",
+                    "strip-indent": "^1.0.1"
                   },
                   "dependencies": {
                     "indent-string": {
@@ -1508,7 +1567,7 @@
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                       "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                       },
                       "dependencies": {
                         "repeating": {
@@ -1516,7 +1575,7 @@
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
                           "requires": {
-                            "is-finite": "1.0.2"
+                            "is-finite": "^1.0.0"
                           },
                           "dependencies": {
                             "is-finite": {
@@ -1524,7 +1583,7 @@
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
                               "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
                               "requires": {
-                                "number-is-nan": "1.0.1"
+                                "number-is-nan": "^1.0.0"
                               },
                               "dependencies": {
                                 "number-is-nan": {
@@ -1543,7 +1602,7 @@
                       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
                       "requires": {
-                        "get-stdin": "4.0.1"
+                        "get-stdin": "^4.0.1"
                       }
                     }
                   }
@@ -1567,13 +1626,13 @@
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
           "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
           "requires": {
-            "async": "0.2.10",
-            "colors": "0.6.2",
-            "cycle": "1.0.3",
-            "eyes": "0.1.8",
-            "isstream": "0.1.2",
-            "pkginfo": "0.3.1",
-            "stack-trace": "0.0.9"
+            "async": "0.2.x",
+            "colors": "0.6.x",
+            "cycle": "1.0.x",
+            "eyes": "0.1.x",
+            "isstream": "0.1.x",
+            "pkginfo": "0.3.x",
+            "stack-trace": "0.0.x"
           },
           "dependencies": {
             "async": {
@@ -1623,10 +1682,10 @@
         "adm-zip": "0.4.11",
         "archiver": "1.0.0",
         "async": "1.5.2",
-        "bluebird": "3.5.1",
+        "bluebird": "^3.4.6",
         "bson": "0.4.22",
         "csvtojson": "0.3.6",
-        "env-var": "2.4.3",
+        "env-var": "~2.4.3",
         "jcsv": "0.0.3",
         "lodash": "2.4.1",
         "mongodb": "2.1.18",
@@ -1643,14 +1702,14 @@
           "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.0.0.tgz",
           "integrity": "sha1-3h1hCC6Ud1W1mbs7wnEwpMhZ/IM=",
           "requires": {
-            "archiver-utils": "1.3.0",
-            "async": "1.5.2",
-            "buffer-crc32": "0.2.13",
-            "glob": "7.1.2",
-            "lodash": "4.17.4",
-            "readable-stream": "2.3.3",
-            "tar-stream": "1.5.4",
-            "zip-stream": "1.2.0"
+            "archiver-utils": "^1.0.0",
+            "async": "^1.5.0",
+            "buffer-crc32": "^0.2.1",
+            "glob": "^7.0.0",
+            "lodash": "^4.8.0",
+            "readable-stream": "^2.0.0",
+            "tar-stream": "^1.5.0",
+            "zip-stream": "^1.0.0"
           },
           "dependencies": {
             "lodash": {
@@ -1665,12 +1724,12 @@
           "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
           "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
           "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lazystream": "1.0.0",
-            "lodash": "4.17.4",
-            "normalize-path": "2.1.1",
-            "readable-stream": "2.3.3"
+            "glob": "^7.0.0",
+            "graceful-fs": "^4.1.0",
+            "lazystream": "^1.0.0",
+            "lodash": "^4.8.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
@@ -1695,7 +1754,7 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
           "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "^2.0.5"
           }
         },
         "bluebird": {
@@ -1708,7 +1767,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -1727,10 +1786,10 @@
           "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
           "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
           "requires": {
-            "buffer-crc32": "0.2.13",
-            "crc32-stream": "2.0.0",
-            "normalize-path": "2.1.1",
-            "readable-stream": "2.3.3"
+            "buffer-crc32": "^0.2.1",
+            "crc32-stream": "^2.0.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
           }
         },
         "concat-map": {
@@ -1753,8 +1812,8 @@
           "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
           "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
           "requires": {
-            "crc": "3.5.0",
-            "readable-stream": "2.3.3"
+            "crc": "^3.4.4",
+            "readable-stream": "^2.0.0"
           }
         },
         "csvtojson": {
@@ -1767,7 +1826,7 @@
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
           "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "env-var": {
@@ -1775,7 +1834,7 @@
           "resolved": "https://registry.npmjs.org/env-var/-/env-var-2.4.3.tgz",
           "integrity": "sha1-Ge4UFMEQwmDZBxXOqWTA/0kYiZU=",
           "requires": {
-            "verror": "1.6.1"
+            "verror": "~1.6.1"
           }
         },
         "es6-promise": {
@@ -1798,12 +1857,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -1816,8 +1875,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -1840,7 +1899,7 @@
           "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
           "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "^2.0.5"
           }
         },
         "lodash": {
@@ -1853,7 +1912,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "mongodb": {
@@ -1876,10 +1935,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
               "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             },
             "string_decoder": {
@@ -1894,8 +1953,8 @@
           "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
           "integrity": "sha1-kGhLO3xzVtZa41Y5HTCw8kiATHo=",
           "requires": {
-            "bson": "0.4.23",
-            "require_optional": "1.0.1"
+            "bson": "~0.4.23",
+            "require_optional": "~1.0.0"
           },
           "dependencies": {
             "bson": {
@@ -1910,7 +1969,7 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "once": {
@@ -1918,7 +1977,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "path-is-absolute": {
@@ -1936,13 +1995,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "remove-trailing-separator": {
@@ -1955,8 +2014,8 @@
           "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
           "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
           "requires": {
-            "resolve-from": "2.0.0",
-            "semver": "5.4.1"
+            "resolve-from": "^2.0.0",
+            "semver": "^5.1.0"
           }
         },
         "resolve-from": {
@@ -1984,7 +2043,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "tar-stream": {
@@ -1992,10 +2051,10 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
           "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
           "requires": {
-            "bl": "1.2.1",
-            "end-of-stream": "1.4.0",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "bl": "^1.0.0",
+            "end-of-stream": "^1.0.0",
+            "readable-stream": "^2.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "util-deprecate": {
@@ -2027,10 +2086,10 @@
           "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
           "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
           "requires": {
-            "archiver-utils": "1.3.0",
-            "compress-commons": "1.2.2",
-            "lodash": "4.17.4",
-            "readable-stream": "2.3.3"
+            "archiver-utils": "^1.3.0",
+            "compress-commons": "^1.2.0",
+            "lodash": "^4.8.0",
+            "readable-stream": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
@@ -2048,7 +2107,7 @@
       "integrity": "sha1-zgaBGwuaFgSU2lS5m9bwk3wWLlo=",
       "requires": {
         "async": "0.2.9",
-        "fhlog": "0.13.1"
+        "fhlog": "^0.13.0"
       },
       "dependencies": {
         "async": {
@@ -2061,14 +2120,14 @@
           "resolved": "https://registry.npmjs.org/fhlog/-/fhlog-0.13.1.tgz",
           "integrity": "sha512-tRdnx3V32cJ4k3Bkf/QVd4hpbhcqwaPAC5hnLk7GGY7cLaJj36TaKKW7ydxJYMPMSe6bkWWayMLO6qckQxdTtw==",
           "requires": {
-            "async": "0.9.2",
-            "brfs": "1.4.4",
-            "colors": "1.0.3",
+            "async": "~0.9.0",
+            "brfs": "~1.4.4",
+            "colors": "~1.0.3",
             "html5-fs": "0.0.1",
-            "lodash": "2.4.2",
-            "moment": "2.19.3",
-            "safejson": "1.0.1",
-            "xtend": "4.0.1"
+            "lodash": "~2.4.1",
+            "moment": "~2.19.3",
+            "safejson": "~1.0.0",
+            "xtend": "~4.0.0"
           },
           "dependencies": {
             "async": {
@@ -2081,10 +2140,10 @@
               "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.4.4.tgz",
               "integrity": "sha512-rX2qc9hkpLPiwdu1HkLY642rwwo3X6N+ZPyEPdNn3OUKV/B2BRP7dHdnkhGantOJLVoTluNYBi4VecHb2Kq2hw==",
               "requires": {
-                "quote-stream": "1.0.2",
-                "resolve": "1.5.0",
-                "static-module": "2.1.1",
-                "through2": "2.0.3"
+                "quote-stream": "^1.0.1",
+                "resolve": "^1.1.5",
+                "static-module": "^2.1.1",
+                "through2": "^2.0.0"
               },
               "dependencies": {
                 "quote-stream": {
@@ -2093,8 +2152,8 @@
                   "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
                   "requires": {
                     "buffer-equal": "0.0.1",
-                    "minimist": "1.2.0",
-                    "through2": "2.0.3"
+                    "minimist": "^1.1.3",
+                    "through2": "^2.0.0"
                   },
                   "dependencies": {
                     "buffer-equal": {
@@ -2114,7 +2173,7 @@
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
                   "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
                   "requires": {
-                    "path-parse": "1.0.5"
+                    "path-parse": "^1.0.5"
                   },
                   "dependencies": {
                     "path-parse": {
@@ -2129,17 +2188,17 @@
                   "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.1.1.tgz",
                   "integrity": "sha512-PPLCnxRl74wV38rG1T0rH8Fl2wIktTXFo7/varrZjtSGb/vndZIGkpe4HJVd8hoBYXRkRHW6hlCRAHvmDgrYQQ==",
                   "requires": {
-                    "concat-stream": "1.6.0",
-                    "duplexer2": "0.1.4",
-                    "escodegen": "1.9.0",
-                    "falafel": "2.1.0",
-                    "has": "1.0.1",
-                    "object-inspect": "1.4.1",
-                    "quote-stream": "1.0.2",
-                    "readable-stream": "2.3.3",
-                    "shallow-copy": "0.0.1",
-                    "static-eval": "2.0.0",
-                    "through2": "2.0.3"
+                    "concat-stream": "~1.6.0",
+                    "duplexer2": "~0.1.4",
+                    "escodegen": "~1.9.0",
+                    "falafel": "^2.1.0",
+                    "has": "^1.0.1",
+                    "object-inspect": "~1.4.0",
+                    "quote-stream": "~1.0.2",
+                    "readable-stream": "~2.3.3",
+                    "shallow-copy": "~0.0.1",
+                    "static-eval": "^2.0.0",
+                    "through2": "~2.0.3"
                   },
                   "dependencies": {
                     "concat-stream": {
@@ -2147,9 +2206,9 @@
                       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
                       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.3",
-                        "typedarray": "0.0.6"
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                       },
                       "dependencies": {
                         "inherits": {
@@ -2169,7 +2228,7 @@
                       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
                       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
                       "requires": {
-                        "readable-stream": "2.3.3"
+                        "readable-stream": "^2.0.2"
                       }
                     },
                     "escodegen": {
@@ -2177,11 +2236,11 @@
                       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
                       "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
                       "requires": {
-                        "esprima": "3.1.3",
-                        "estraverse": "4.2.0",
-                        "esutils": "2.0.2",
-                        "optionator": "0.8.2",
-                        "source-map": "0.5.7"
+                        "esprima": "^3.1.3",
+                        "estraverse": "^4.2.0",
+                        "esutils": "^2.0.2",
+                        "optionator": "^0.8.1",
+                        "source-map": "~0.5.6"
                       },
                       "dependencies": {
                         "esprima": {
@@ -2204,12 +2263,12 @@
                           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
                           "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
                           "requires": {
-                            "deep-is": "0.1.3",
-                            "fast-levenshtein": "2.0.6",
-                            "levn": "0.3.0",
-                            "prelude-ls": "1.1.2",
-                            "type-check": "0.3.2",
-                            "wordwrap": "1.0.0"
+                            "deep-is": "~0.1.3",
+                            "fast-levenshtein": "~2.0.4",
+                            "levn": "~0.3.0",
+                            "prelude-ls": "~1.1.2",
+                            "type-check": "~0.3.2",
+                            "wordwrap": "~1.0.0"
                           },
                           "dependencies": {
                             "deep-is": {
@@ -2227,8 +2286,8 @@
                               "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
                               "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
                               "requires": {
-                                "prelude-ls": "1.1.2",
-                                "type-check": "0.3.2"
+                                "prelude-ls": "~1.1.2",
+                                "type-check": "~0.3.2"
                               }
                             },
                             "prelude-ls": {
@@ -2241,7 +2300,7 @@
                               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
                               "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
                               "requires": {
-                                "prelude-ls": "1.1.2"
+                                "prelude-ls": "~1.1.2"
                               }
                             },
                             "wordwrap": {
@@ -2264,10 +2323,10 @@
                       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
                       "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
                       "requires": {
-                        "acorn": "5.4.1",
-                        "foreach": "2.0.5",
+                        "acorn": "^5.0.0",
+                        "foreach": "^2.0.5",
                         "isarray": "0.0.1",
-                        "object-keys": "1.0.11"
+                        "object-keys": "^1.0.6"
                       },
                       "dependencies": {
                         "acorn": {
@@ -2297,7 +2356,7 @@
                       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
                       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
                       "requires": {
-                        "function-bind": "1.1.1"
+                        "function-bind": "^1.0.2"
                       },
                       "dependencies": {
                         "function-bind": {
@@ -2317,13 +2376,13 @@
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -2356,7 +2415,7 @@
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                           "requires": {
-                            "safe-buffer": "5.1.1"
+                            "safe-buffer": "~5.1.0"
                           }
                         },
                         "util-deprecate": {
@@ -2376,7 +2435,7 @@
                       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz",
                       "integrity": "sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==",
                       "requires": {
-                        "escodegen": "1.9.0"
+                        "escodegen": "^1.8.1"
                       }
                     }
                   }
@@ -2386,8 +2445,8 @@
                   "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
                   "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                   "requires": {
-                    "readable-stream": "2.3.3",
-                    "xtend": "4.0.1"
+                    "readable-stream": "^2.1.5",
+                    "xtend": "~4.0.1"
                   },
                   "dependencies": {
                     "readable-stream": {
@@ -2395,13 +2454,13 @@
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -2434,7 +2493,7 @@
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                           "requires": {
-                            "safe-buffer": "5.1.1"
+                            "safe-buffer": "~5.1.0"
                           }
                         },
                         "util-deprecate": {
@@ -2482,9 +2541,9 @@
       "resolved": "https://registry.npmjs.org/fh-logger/-/fh-logger-0.5.0.tgz",
       "integrity": "sha1-9S06fBNYYgb6TWMgLAhGDyFLCTI=",
       "requires": {
-        "bunyan": "1.8.1",
-        "continuation-local-storage": "3.1.7",
-        "node-uuid": "1.4.7"
+        "bunyan": "^1.5.1",
+        "continuation-local-storage": "^3.1.7",
+        "node-uuid": "^1.4.7"
       },
       "dependencies": {
         "bunyan": {
@@ -2492,10 +2551,10 @@
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.1.tgz",
           "integrity": "sha1-aMakpQLVYgvJ9y1nNoEMGxiYCX8=",
           "requires": {
-            "dtrace-provider": "0.6.0",
-            "moment": "2.13.0",
-            "mv": "2.1.1",
-            "safe-json-stringify": "1.0.3"
+            "dtrace-provider": "~0.6",
+            "moment": "^2.10.6",
+            "mv": "~2",
+            "safe-json-stringify": "~1"
           },
           "dependencies": {
             "dtrace-provider": {
@@ -2504,7 +2563,7 @@
               "integrity": "sha1-CweNVReTfYcxAUUtkUZzdVe3XlE=",
               "optional": true,
               "requires": {
-                "nan": "2.3.5"
+                "nan": "^2.0.8"
               },
               "dependencies": {
                 "nan": {
@@ -2527,9 +2586,9 @@
               "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
               "optional": true,
               "requires": {
-                "mkdirp": "0.5.1",
-                "ncp": "2.0.0",
-                "rimraf": "2.4.5"
+                "mkdirp": "~0.5.1",
+                "ncp": "~2.0.0",
+                "rimraf": "~2.4.0"
               },
               "dependencies": {
                 "mkdirp": {
@@ -2561,7 +2620,7 @@
                   "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                   "optional": true,
                   "requires": {
-                    "glob": "6.0.4"
+                    "glob": "^6.0.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -2570,11 +2629,11 @@
                       "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                       "optional": true,
                       "requires": {
-                        "inflight": "1.0.5",
-                        "inherits": "2.0.1",
-                        "minimatch": "3.0.2",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.0"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -2583,8 +2642,8 @@
                           "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
                           "optional": true,
                           "requires": {
-                            "once": "1.3.3",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -2607,7 +2666,7 @@
                           "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
                           "optional": true,
                           "requires": {
-                            "brace-expansion": "1.1.5"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -2616,7 +2675,7 @@
                               "integrity": "sha1-9bStV04st8zB64Pm/nm47K33pSY=",
                               "optional": true,
                               "requires": {
-                                "balanced-match": "0.4.1",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -2641,7 +2700,7 @@
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -2676,8 +2735,8 @@
           "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.7.tgz",
           "integrity": "sha1-+PfbzS38Zt2gXaDEu1n3yRIMOvY=",
           "requires": {
-            "async-listener": "0.6.0",
-            "emitter-listener": "1.0.1"
+            "async-listener": "^0.6.0",
+            "emitter-listener": "^1.0.1"
           },
           "dependencies": {
             "async-listener": {
@@ -2719,10 +2778,100 @@
         }
       }
     },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
     "geoip-lite": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.0.10.tgz",
-      "integrity": "sha1-VAFgYES1/aUNbUad8AZTA/2vTXA="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.3.1.tgz",
+      "integrity": "sha512-X+SwRYeVpQ8GpAANpD8PKO3CdrV2EsPZ3uBHtiHKg8vjjY0ozlKV8rYb24c4l3dEZUEq42OU+jqKuR9tEEiAsg==",
+      "requires": {
+        "async": "^2.1.1",
+        "colors": "^1.1.2",
+        "glob": "^7.1.1",
+        "iconv-lite": "^0.4.13",
+        "ip-address": "^5.8.9",
+        "lazy": "^1.0.11",
+        "rimraf": "^2.5.2",
+        "save": "^2.3.2",
+        "yauzl": "^2.9.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ip-address": {
+      "version": "5.8.9",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.8.9.tgz",
+      "integrity": "sha512-7ay355oMN34iXhET1BmCJVsHjOTSItEEIIpOs38qUC23AIhOy+xIPnkrTuEFjeLMrTJ7m8KMXWgWfy/2Vn9sDw==",
+      "requires": {
+        "jsbn": "1.1.0",
+        "lodash.find": "^4.6.0",
+        "lodash.max": "^4.0.1",
+        "lodash.merge": "^4.6.0",
+        "lodash.padstart": "^4.6.1",
+        "lodash.repeat": "^4.1.0",
+        "sprintf-js": "1.1.0"
+      }
+    },
+    "jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+    },
+    "lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA="
     },
     "limiter": {
       "version": "1.1.2",
@@ -2733,6 +2882,59 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lines/-/lines-1.0.1.tgz",
       "integrity": "sha1-bDTA1By2fhIqAiXZa5tLPaW0sXk="
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+    },
+    "lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
+    "lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
+    },
+    "lodash.repeat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
+      "integrity": "sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ="
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+    },
+    "mingo": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-1.3.3.tgz",
+      "integrity": "sha1-aSLE0Ufvx3GgFCWixMj3eER4xUY="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "moment": {
       "version": "2.19.3",
@@ -2759,8 +2961,8 @@
           "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
           "integrity": "sha1-kGhLO3xzVtZa41Y5HTCw8kiATHo=",
           "requires": {
-            "bson": "0.4.23",
-            "require_optional": "1.0.1"
+            "bson": "~0.4.23",
+            "require_optional": "~1.0.0"
           },
           "dependencies": {
             "bson": {
@@ -2773,8 +2975,8 @@
               "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
               "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
               "requires": {
-                "resolve-from": "2.0.0",
-                "semver": "5.5.0"
+                "resolve-from": "^2.0.0",
+                "semver": "^5.1.0"
               },
               "dependencies": {
                 "resolve-from": {
@@ -2796,10 +2998,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
           "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           },
           "dependencies": {
             "core-util-is": {
@@ -2846,12 +3048,20 @@
       "resolved": "https://registry.npmjs.org/node-fs/-/node-fs-0.1.5.tgz",
       "integrity": "sha1-CoD2ZAfqVfKGFXs/VXcoJTZ+51c="
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
     "optimist": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
       "requires": {
-        "wordwrap": "0.0.3"
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -2861,33 +3071,51 @@
         }
       }
     },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "~2.3"
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "aws-sign2": {
@@ -2910,7 +3138,7 @@
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           },
           "dependencies": {
             "delayed-stream": {
@@ -2935,9 +3163,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           },
           "dependencies": {
             "asynckit": {
@@ -2952,8 +3180,8 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
           },
           "dependencies": {
             "ajv": {
@@ -2961,10 +3189,10 @@
               "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
               "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
               "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
               },
               "dependencies": {
                 "co": {
@@ -3001,10 +3229,10 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
           },
           "dependencies": {
             "boom": {
@@ -3012,7 +3240,7 @@
               "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
               "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
               "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.x.x"
               }
             },
             "cryptiles": {
@@ -3020,7 +3248,7 @@
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
               "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
               "requires": {
-                "boom": "5.2.0"
+                "boom": "5.x.x"
               },
               "dependencies": {
                 "boom": {
@@ -3028,7 +3256,7 @@
                   "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
                   "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                   "requires": {
-                    "hoek": "4.2.0"
+                    "hoek": "4.x.x"
                   }
                 }
               }
@@ -3043,7 +3271,7 @@
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
               "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
               "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.x.x"
               }
             }
           }
@@ -3053,9 +3281,9 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -3089,9 +3317,9 @@
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
                   "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
                   "requires": {
-                    "assert-plus": "1.0.0",
+                    "assert-plus": "^1.0.0",
                     "core-util-is": "1.0.2",
-                    "extsprintf": "1.3.0"
+                    "extsprintf": "^1.2.0"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -3108,14 +3336,14 @@
               "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
               "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
               "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
               },
               "dependencies": {
                 "asn1": {
@@ -3129,7 +3357,7 @@
                   "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                   "optional": true,
                   "requires": {
-                    "tweetnacl": "0.14.5"
+                    "tweetnacl": "^0.14.3"
                   }
                 },
                 "dashdash": {
@@ -3137,7 +3365,7 @@
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                   "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                   "requires": {
-                    "assert-plus": "1.0.0"
+                    "assert-plus": "^1.0.0"
                   }
                 },
                 "ecc-jsbn": {
@@ -3146,7 +3374,7 @@
                   "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                   "optional": true,
                   "requires": {
-                    "jsbn": "0.1.1"
+                    "jsbn": "~0.1.0"
                   }
                 },
                 "getpass": {
@@ -3154,7 +3382,7 @@
                   "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
                   "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                   "requires": {
-                    "assert-plus": "1.0.0"
+                    "assert-plus": "^1.0.0"
                   }
                 },
                 "jsbn": {
@@ -3193,7 +3421,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "~1.30.0"
           },
           "dependencies": {
             "mime-db": {
@@ -3233,7 +3461,7 @@
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
           "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           },
           "dependencies": {
             "punycode": {
@@ -3248,7 +3476,7 @@
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "uuid": {
@@ -3258,15 +3486,89 @@
         }
       }
     },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "^7.0.5"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "save": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/save/-/save-2.3.2.tgz",
+      "integrity": "sha1-hZJnS1VlzE4SvG3dnLCfgo4+z30=",
+      "requires": {
+        "async": "^2.4.1",
+        "event-stream": "^3.3.4",
+        "lodash.assign": "^4.2.0",
+        "mingo": "^1.3.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        }
+      }
+    },
     "semver": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
       "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
     },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "requires": {
+        "through": "2"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.0.tgz",
+      "integrity": "sha1-z/yvcC2vZeo5u04PorKZzsGhvkY="
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
     "underscore": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     }
   }
 }

--- a/fh-messaging/package.json
+++ b/fh-messaging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-messaging",
   "description": "FeedHenry Messaging Server",
-  "version": "3.3.1-BUILD-NUMBER",
+  "version": "3.3.12BUILD-NUMBER",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-messaging.git"

--- a/fh-messaging/package.json
+++ b/fh-messaging/package.json
@@ -44,7 +44,7 @@
     "fh-db": "3.3.1",
     "fh-health": "0.3.2",
     "fh-logger": "0.5.0",
-    "geoip-lite": "~1.0.5",
+    "geoip-lite": "1.3.1",
     "limiter": "~1.1.2",
     "lines": "1.0.1",
     "moment": "2.19.3",


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21092

# What
Upgrade version of the geoip-lite from ~1.0.5 to 1.3.1

# Why
Intermittent errors as follows are faced in the logs.

```
{"name":"messaging","hostname":"ema1-core-util1","pid":11303,"level":40,"msg":"Error from geoip lookup, continuing anyway with no country for ip: 107.178.192.64","time":"2018-03-13T11:31:00.974Z","v":0}
```
 
This lib is responsible to get the geolocation of the IP received the requests of the client applications for metrics proposes. Then, since we are with an old version and the latest did not have break changes but contain fix bugs and improvements related to this action the best approach here in order to try to solve or at least avoid this issue is using it.  

# How
`npm install --save -save-exact geoip-lite@1.3.1`

Following some observations. 

#### The diff commits from `1.0.7` to `1.3.1` can be check [here](https://github.com/bluesmoon/node-geoip/compare/v1.0.7...master)
#### Some commits can avoid this scenario/issue as follows. 
- https://github.com/bluesmoon/node-geoip/commit/8c34926eabccf06b10c884c7cd25b8098260e6e4
- https://github.com/bluesmoon/node-geoip/commit/a64195e3d5b181de149aa0921ec525dd294038fe
- https://github.com/bluesmoon/node-geoip/commit/a3fdea361f759e3ab6b4c75498e820b3aa38f972

# Verification Steps

Since the issue is intermittent then we are not able to reproduce and check it. The goal here is just to ensure that no issues will be introduced with this change. Note that it is not a major version and not break changes shows be added into them should still working fine with this version. 

This project has many tests and CI then check if it finished with success should be enough for we move forward with it. 
